### PR TITLE
SOAP1.2 - fixes error envelop for empty faultcodes list

### DIFF
--- a/spyne/protocol/soap/soap12.py
+++ b/spyne/protocol/soap/soap12.py
@@ -106,6 +106,10 @@ class Soap12(Soap11):
                     child_subcode = self.generate_subcode(value, child_subcode)
                 else:
                     child_subcode = self.generate_subcode(value)
+
+            if child_subcode == 0:
+                child_subcode = self.generate_subcode(value)
+
             code.append(child_subcode)
 
             _append(subelts, code)


### PR DESCRIPTION
If the faultcodes list is empty, child_subcode remains 0 (== Internal Server Error), which is okay. But it is not wrapped in an element.

This PR fixes it.